### PR TITLE
feat: configure production environment with Docker and Nginx

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -20,6 +20,10 @@ DEBUG = env.bool('DEBUG', default=False)
 ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=[])
 
 
+USE_X_FORWARDED_HOST = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+CSRF_TRUSTED_ORIGINS = ['https://shr.today', 'https://www.shr.today']
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -85,21 +89,6 @@ else:
     }
 
 
-AUTH_PASSWORD_VALIDATORS = [
-    {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
-]
-
 LANGUAGE_CODE = 'en-us'
 
 TIME_ZONE = 'UTC'
@@ -109,8 +98,10 @@ USE_I18N = True
 USE_TZ = True
 
 STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 STATICFILES_DIRS = [
     BASE_DIR / 'static',
 ]
+
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "django>=5.2.3",
     "django-environ>=0.12.0",
+    "gunicorn>=23.0.0",
     "psycopg[binary]>=3.2.9",
 ]
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -50,6 +50,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "django" },
     { name = "django-environ" },
+    { name = "gunicorn" },
     { name = "psycopg", extra = ["binary"] },
 ]
 
@@ -66,6 +67,7 @@ dev = [
 requires-dist = [
     { name = "django", specifier = ">=5.2.3" },
     { name = "django-environ", specifier = ">=0.12.0" },
+    { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
 ]
 
@@ -100,6 +102,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/65/f9/66af4019ee952fc84b8fe5b523fceb7f9e631ed8484417b6f1e3092f8290/faker-37.4.0.tar.gz", hash = "sha256:7f69d579588c23d5ce671f3fa872654ede0e67047820255f43a4aa1925b89780", size = 1901976 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/5e/c8c3c5ea0896ab747db2e2889bf5a6f618ed291606de6513df56ad8670a8/faker-37.4.0-py3-none-any.whl", hash = "sha256:cb81c09ebe06c32a10971d1bbdb264bb0e22b59af59548f011ac4809556ce533", size = 1942992 },
+]
+
+[[package]]
+name = "gunicorn"
+version = "23.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", size = 85029 },
 ]
 
 [[package]]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,5 +34,13 @@ services:
       - pgdata:/var/lib/postgresql/data
     restart: on-failure
 
+  nginx:
+    image: nginx:latest
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/dev.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - backend
 volumes:
   pgdata:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,43 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    working_dir: /app/backend
+    command: >
+      bash -c "python manage.py migrate && python manage.py collectstatic --noinput &&
+      gunicorn config.wsgi:application --bind 0.0.0.0:8000
+    volumes:
+      - static_volume:/app/backend/staticfiles
+    env_file:
+      - ./backend/.env
+    environment:
+      - DEBUG=False
+      - USE_POSTGRES=True
+    depends_on:
+      - db
+
+  db:
+    image: postgres:15
+    env_file:
+      - ./backend/.env
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    restart: on-failure
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/prod.conf:/etc/nginx/conf.d/default.conf
+      - static_volume:/staticfiles
+    depends_on:
+      - backend
+    restart: on-failure
+
+volumes:
+  pgdata:
+  static_volume:

--- a/nginx/dev.conf
+++ b/nginx/dev.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name localhost 127.0.0.1;
+
+    location / {
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/nginx/prod.conf
+++ b/nginx/prod.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    server_name shr.today www.shr.today; // 換成你的網域名稱
+
+    location / {
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
+    location /static/ {
+        alias /staticfiles/;
+    }
+}


### PR DESCRIPTION
- **Production 環境建置**
  - 新增 docker-compose.prod.yml，整合 backend、PostgreSQL、nginx，並設計 production 專用 volume（`static_volume`）。
  - backend 啟動時自動執行 migrate、collectstatic，並以 gunicorn 啟動 Django。
  - nginx production 設定檔 prod.conf，反向代理 backend 並服務 `/static/` 靜態檔案。

- **Django 設定優化**
  - `settings.py` 新增 production 相關設定：
    - `USE_X_FORWARDED_HOST = True`
    - `SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')`
    - `CSRF_TRUSTED_ORIGINS` 設定正式網域
    - 新增 `STATIC_ROOT`，方便 collectstatic 輸出靜態檔案
  - `pyproject.toml` 及 `uv.lock` 新增 gunicorn 依賴

- **nginx dev/prod 配置**
  - 新增 dev.conf，供本地開發用 nginx 反向代理
  - 新增 prod.conf，供 production 用 nginx 反向代理與靜態檔案服務