### PR TITLE
feat: add fetch page info, password-protected redirect, and UI/UX enhancementsFeature/20 shortener layout

### DIFF
--- a/backend/links/urls.py
+++ b/backend/links/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path('api/links/shortener', views.link_shortener_api, name='link_shortener_api'),
     path('<slug:slug>/', views.redirect_link, name='redirect_link'),
     path('links/new/', views.new, name='new'),
+    path('api/fetch-page-info/', views.fetch_page_info_api, name='fetch_page_info_api'),
 ]

--- a/backend/links/urls.py
+++ b/backend/links/urls.py
@@ -9,4 +9,5 @@ app_name = 'links'
 urlpatterns = [
     path('api/links/shortener', views.link_shortener_api, name='link_shortener_api'),
     path('<slug:slug>/', views.redirect_link, name='redirect_link'),
+    path('links/new/', views.new, name='new'),
 ]

--- a/backend/links/views.py
+++ b/backend/links/views.py
@@ -3,6 +3,7 @@ import json
 from django.contrib.auth.hashers import check_password
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect, JsonResponse
+from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
@@ -94,3 +95,10 @@ def redirect_link(request, slug):
     link.save(update_fields=['click_count'])
 
     return HttpResponseRedirect(link.original_url)
+
+
+def new(req):
+    return render(
+        req,
+        'links/new.html',
+    )

--- a/backend/links/views.py
+++ b/backend/links/views.py
@@ -81,15 +81,20 @@ def redirect_link(request, slug):
         )
 
     if link.password:
-        input_password = request.GET.get('password')
-        if not input_password:
-            return JsonResponse(
-                {'success': False, 'message': 'Password required.'}, status=403
-            )
-        if not check_password(input_password, link.password):
-            return JsonResponse(
-                {'success': False, 'message': 'Invalid password.'}, status=403
-            )
+        if request.method == 'POST':
+            input_password = request.POST.get('password')
+
+            if check_password(input_password, link.password):
+                return HttpResponseRedirect(link.original_url)
+
+            else:
+                return render(
+                    request,
+                    'links/enter_password.html',
+                    {'slug': slug, 'error': '密碼不正確.'},
+                )
+
+        return render(request, 'links/enter_password.html', {'slug': slug})
 
     link.click_count += 1
     link.save(update_fields=['click_count'])

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,10 +5,12 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "beautifulsoup4>=4.13.4",
     "django>=5.2.3",
     "django-environ>=0.12.0",
     "gunicorn>=23.0.0",
     "psycopg[binary]>=3.2.9",
+    "requests>=2.32.4",
 ]
 
 [dependency-groups]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -12,6 +12,50 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/cd/30110dc0ffcf3b131156077b90e9f60ed75711223f306da4db08eff8403b/beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b", size = 187285 },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.6.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/f7/f14b46d4bcd21092d7d3ccef689615220d8a08fb25e564b65d20738e672e/certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b", size = 158753 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057", size = 157650 },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/12/a93df3366ed32db1d907d7593a94f1fe6293903e3e92967bebd6950ed12c/charset_normalizer-3.4.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0", size = 199622 },
+    { url = "https://files.pythonhosted.org/packages/04/93/bf204e6f344c39d9937d3c13c8cd5bbfc266472e51fc8c07cb7f64fcd2de/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf", size = 143435 },
+    { url = "https://files.pythonhosted.org/packages/22/2a/ea8a2095b0bafa6c5b5a55ffdc2f924455233ee7b91c69b7edfcc9e02284/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e", size = 153653 },
+    { url = "https://files.pythonhosted.org/packages/b6/57/1b090ff183d13cef485dfbe272e2fe57622a76694061353c59da52c9a659/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1", size = 146231 },
+    { url = "https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c", size = 148243 },
+    { url = "https://files.pythonhosted.org/packages/c0/0f/9abe9bd191629c33e69e47c6ef45ef99773320e9ad8e9cb08b8ab4a8d4cb/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691", size = 150442 },
+    { url = "https://files.pythonhosted.org/packages/67/7c/a123bbcedca91d5916c056407f89a7f5e8fdfce12ba825d7d6b9954a1a3c/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0", size = 145147 },
+    { url = "https://files.pythonhosted.org/packages/ec/fe/1ac556fa4899d967b83e9893788e86b6af4d83e4726511eaaad035e36595/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b", size = 153057 },
+    { url = "https://files.pythonhosted.org/packages/2b/ff/acfc0b0a70b19e3e54febdd5301a98b72fa07635e56f24f60502e954c461/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff", size = 156454 },
+    { url = "https://files.pythonhosted.org/packages/92/08/95b458ce9c740d0645feb0e96cea1f5ec946ea9c580a94adfe0b617f3573/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b", size = 154174 },
+    { url = "https://files.pythonhosted.org/packages/78/be/8392efc43487ac051eee6c36d5fbd63032d78f7728cb37aebcc98191f1ff/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148", size = 149166 },
+    { url = "https://files.pythonhosted.org/packages/44/96/392abd49b094d30b91d9fbda6a69519e95802250b777841cf3bda8fe136c/charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7", size = 98064 },
+    { url = "https://files.pythonhosted.org/packages/e9/b0/0200da600134e001d91851ddc797809e2fe0ea72de90e09bec5a2fbdaccb/charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980", size = 105641 },
+    { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -48,10 +92,12 @@ name = "django-url-shortener"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "django" },
     { name = "django-environ" },
     { name = "gunicorn" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "requests" },
 ]
 
 [package.dev-dependencies]
@@ -65,10 +111,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.13.4" },
     { name = "django", specifier = ">=5.2.3" },
     { name = "django-environ", specifier = ">=0.12.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
+    { name = "requests", specifier = ">=2.32.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -114,6 +162,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", size = 85029 },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
 ]
 
 [[package]]
@@ -241,6 +298,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.32.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847 },
+]
+
+[[package]]
 name = "ruff"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -263,6 +335,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/ef/b960ab4818f90ff59e571d03c3f992828d4683561095e80f9ef31f3d58b7/ruff-0.12.0-py3-none-win32.whl", hash = "sha256:7162a4c816f8d1555eb195c46ae0bd819834d2a3f18f98cc63819a7b46f474fb", size = 10525289 },
     { url = "https://files.pythonhosted.org/packages/34/93/8b16034d493ef958a500f17cda3496c63a537ce9d5a6479feec9558f1695/ruff-0.12.0-py3-none-win_amd64.whl", hash = "sha256:d00b7a157b8fb6d3827b49d3324da34a1e3f93492c1f97b08e222ad7e9b291e0", size = 11598311 },
     { url = "https://files.pythonhosted.org/packages/d0/33/4d3e79e4a84533d6cd526bfb42c020a23256ae5e4265d858bd1287831f7d/ruff-0.12.0-py3-none-win_arm64.whl", hash = "sha256:8cd24580405ad8c1cc64d61725bca091d6b6da7eb3d36f72cc605467069d7e8b", size = 10724946 },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677 },
 ]
 
 [[package]]
@@ -290,4 +371,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839 },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795 },
 ]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,7 +6,7 @@ services:
     working_dir: /app/backend
     command: >
       bash -c "python manage.py migrate && python manage.py collectstatic --noinput &&
-      gunicorn config.wsgi:application --bind 0.0.0.0:8000
+      gunicorn config.wsgi:application --bind 0.0.0.0:8000"
     volumes:
       - static_volume:/app/backend/staticfiles
     env_file:

--- a/frontend/src/scripts/input.js
+++ b/frontend/src/scripts/input.js
@@ -1,3 +1,6 @@
 import Alpine from 'alpinejs';
+import { shortenerForm } from './shortenerForm.js';
+
+Alpine.data('shortenerForm', shortenerForm);
 
 Alpine.start();

--- a/frontend/src/scripts/shortenerForm.js
+++ b/frontend/src/scripts/shortenerForm.js
@@ -1,0 +1,63 @@
+export function shortenerForm() {
+  return {
+    original_url: '',
+    short_url: '',
+    password: '',
+    notes: '',
+    is_active: true,
+    isLoading: false,
+    errorMessage: '',
+
+    async submit() {
+      this.isLoading = true;
+      this.errorMessage = '';
+      if (this.$refs.result) this.$refs.result.innerHTML = '';
+
+      const payload = {
+        original_url: this.original_url,
+        slug: this.short_url || undefined,
+        password: this.password || undefined,
+        notes: this.notes || undefined,
+        is_active: this.is_active,
+      };
+
+      try {
+        const res = await fetch('/api/links/shortener', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          throw new Error(data.message || '發生未知錯誤');
+        }
+
+        if (data.success) {
+          if (this.$refs.result) {
+            this.$refs.result.innerHTML = `
+              <div class="alert alert-success mt-4">
+                ${data.message || '短網址建立成功'}:
+                <a href="${data.short_url}" target="_blank" class="link link-primary">${data.short_url}</a>
+              </div>
+            `;
+          }
+          this.original_url = '';
+          this.short_url = '';
+          this.password = '';
+          this.notes = '';
+          this.is_active = true;
+        } else {
+          this.errorMessage = data.message;
+        }
+      } catch (error) {
+        this.errorMessage = error.message;
+      } finally {
+        this.isLoading = false;
+      }
+    },
+  };
+}

--- a/frontend/src/scripts/shortenerForm.js
+++ b/frontend/src/scripts/shortenerForm.js
@@ -6,11 +6,14 @@ export function shortenerForm() {
     notes: '',
     is_active: true,
     isLoading: false,
-    errorMessage: '',
+    isFetchingInfo: false,
+    message: '',
+    messageType: '',
+    short_url_result: '',
 
     async submit() {
       this.isLoading = true;
-      this.errorMessage = '';
+      this.message = '';
       if (this.$refs.result) this.$refs.result.innerHTML = '';
 
       const payload = {
@@ -37,27 +40,71 @@ export function shortenerForm() {
         }
 
         if (data.success) {
-          if (this.$refs.result) {
-            this.$refs.result.innerHTML = `
-              <div class="alert alert-success mt-4">
-                ${data.message || '短網址建立成功'}:
-                <a href="${data.short_url}" target="_blank" class="link link-primary">${data.short_url}</a>
-              </div>
-            `;
-          }
+          this.message = data.message;
+          this.messageType = 'success';
+          this.short_url_result = data.short_url;
+
           this.original_url = '';
           this.short_url = '';
           this.password = '';
           this.notes = '';
           this.is_active = true;
         } else {
-          this.errorMessage = data.message;
+          this.message = data.message;
+          this.messageType = 'error';
+          this.short_url_result = '';
         }
       } catch (error) {
-        this.errorMessage = error.message;
+        this.message = error.message;
+        this.messageType = 'error';
       } finally {
         this.isLoading = false;
       }
+    },
+
+    async fetchPageInfo() {
+      if (!this.original_url) {
+        alert('請先輸入或貼上完整的網址！');
+        return;
+      }
+
+      this.isFetchingInfo = true;
+      this.message = ''; // 清除舊的錯誤訊息
+
+      try {
+        const res = await fetch('/api/fetch-page-info/', {
+          // <-- 指向新的 API
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ original_url: this.original_url }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          throw new Error(data.message || '抓取資訊失敗');
+        }
+
+        // 成功時，將回傳的 notes 文字更新到 Alpine 的狀態中
+        // 因為 textarea 綁定了 x-model="notes"，所以會自動更新
+        this.notes = data.notes;
+      } catch (error) {
+        this.message = error.message;
+      } finally {
+        this.isFetchingInfo = false;
+      }
+    },
+
+    copyToClipboard(text) {
+      navigator.clipboard
+        .writeText(text)
+        .then(() => {
+          alert('已複製短網址！');
+          // 如果有需要，可以在這裡更新 UI 或做其他處理
+        })
+        .catch(() => {
+          alert('複製失敗');
+        });
     },
   };
 }

--- a/frontend/templates/layouts/default.html
+++ b/frontend/templates/layouts/default.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>URL Shortener</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" />
     <link rel="stylesheet" href="{% static 'assets/styles/style.css' %}" />
     <script type="module" src="{% static 'assets/scripts/app.js' %}"></script>
   </head>

--- a/frontend/templates/layouts/default.html
+++ b/frontend/templates/layouts/default.html
@@ -1,0 +1,35 @@
+{% load static %}
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>URL Shortener</title>
+    <link rel="stylesheet" href="{% static 'assets/styles/style.css' %}" />
+    <script type="module" src="{% static 'assets/scripts/app.js' %}"></script>
+  </head>
+  <body class="min-h-screen flex flex-col bg-base-100">
+    <!-- Navbar -->
+    <nav class="navbar bg-base-200 shadow mb-4">
+      <div class="container mx-auto flex justify-between items-center px-4">
+        <a href="/" class="text-xl font-bold text-primary">URL Shortener</a>
+        <div>
+          <!-- 可以在這裡加上登入/登出按鈕或其他連結 -->
+        </div>
+      </div>
+    </nav>
+
+    <!-- Django Messages -->
+    <div id="messages-container">{% include "shared/messages.html" %}</div>
+
+    <!-- Main Content -->
+    <main class="container mx-auto px-4">{% block main %}{% endblock %}</main>
+
+    <!-- Footer -->
+    <footer class="footer footer-center p-4 bg-base-200 text-base-content mt-8">
+      <div>
+        <p>&copy; {{ now|date:"Y" }} URL Shortener. All rights reserved.</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/frontend/templates/links/enter_password.html
+++ b/frontend/templates/links/enter_password.html
@@ -1,0 +1,19 @@
+{% extends 'layouts/default.html' %} {% block main %}
+
+<div class="card w-full max-w-sm shadow-xl bg-base-100">
+  <div class="card-body">
+    <h2 class="card-title justify-center mb-4">請輸入密碼</h2>
+    <form method="post" class="space-y-4">
+      {% csrf_token %}
+      <input type="password" name="password" placeholder="Enter password" class="input input-bordered w-full" required />
+      {% if error %}
+      <div class="alert alert-error py-2">{{ error }}</div>
+      {% endif %}
+      <div class="card-actions justify-end">
+        <button type="submit" class="btn btn-primary w-full">確定</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock main %}

--- a/frontend/templates/links/enter_password.html
+++ b/frontend/templates/links/enter_password.html
@@ -7,7 +7,7 @@
       {% csrf_token %}
       <input type="password" name="password" placeholder="Enter password" class="input input-bordered w-full" required />
       {% if error %}
-      <div class="alert alert-error py-2">{{ error }}</div>
+      <div x-data="{ show: true }" x-init="setTimeout(() => show = false, 1000)" x-show="show" class="alert mt-4 fixed left-1/2 top-6 -translate-x-1/2 z-50 alert-error">{{ error }}</div>
       {% endif %}
       <div class="card-actions justify-end">
         <button type="submit" class="btn btn-primary w-full">確定</button>

--- a/frontend/templates/links/new.html
+++ b/frontend/templates/links/new.html
@@ -2,34 +2,60 @@
 
 <div x-data="shortenerForm()" @submit.prevent="submit" class="max-w-md mx-auto p-4">
   <form>
-    <input x-model="original_url" placeholder="完整網址" class="input input-bordered w-full mb-2" />
-    <input x-model="short_url" placeholder="自訂代號 (可空)" class="input input-bordered w-full mb-2" />
-    <input x-model="password" placeholder="密碼 (選填)" type="password" class="input input-bordered w-full mb-2" />
-    <div style="margin-bottom: 10px">
-      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px">
+    <div>
+      <label for="original_url">連結</label>
+      <input id="original_url" x-model="original_url" placeholder="完整網址" class="input input-bordered w-full mb-2" />
+
+      <p class="text-sm text-gray-500 mb-2">貼上的網址若包含UTM標籤，會自動解析並使用 Google Analytics 功能</p>
+    </div>
+
+    <div>
+      <label for="short_url">短網址</label>
+      <input id="short_url" x-model="short_url" placeholder="自訂代號 (可空)" class="input input-bordered w-full mb-2" />
+      <p class="text-sm text-gray-500 mb-2">可自行填寫，或是自動產生</p>
+    </div>
+
+    <div>
+      <label for="password">密碼保護</label>
+      <input id="password" x-model="password" placeholder="密碼 (選填)" type="password" class="input input-bordered w-full mb-2" />
+      <p class="text-sm text-gray-500 mb-2">若不使用密碼保護，將此欄位清空即可</p>
+    </div>
+
+    <div class="mb-2">
+      <div class="flex justify-between items-center mb-1">
         <label for="notes">備註說明</label>
-        <!-- 按鈕觸發 fetchPageInfo 方法 -->
-        <button type="button" @click.prevent="fetchPageInfo" :disabled="isFetchingInfo" style="padding: 2px 8px; font-size: 0.8em">
+        <button type="button" class="btn btn-ghost" @click.prevent="fetchPageInfo" :disabled="isFetchingInfo" class="btn btn-sm btn-outline ml-2">
+          <i class="fa-solid fa-cloud-arrow-down"></i>
           <span x-text="isFetchingInfo ? '抓取中...' : '取得頁面資訊'"></span>
         </button>
       </div>
-      <!-- textarea 使用 x-model 雙向綁定 notes 狀態 -->
-      <textarea id="notes" x-model="notes" rows="4" style="width: 100%"></textarea>
+      <textarea id="notes" x-model="notes" rows="4" class="w-full border border-gray-300"></textarea>
     </div>
     <label class="flex items-center mb-2">
       <input x-model="is_active" type="checkbox" class="checkbox mr-2" />
-      啟用
+      是否啟用
     </label>
     <button type="submit" class="btn btn-primary" :disabled="isLoading">
       <span x-show="!isLoading">建立</span>
       <span x-show="isLoading" class="loading loading-spinner loading-xs"></span>
     </button>
-    <template x-if="errorMessage">
-      <div class="alert alert-error mt-4" x-text="errorMessage"></div>
+    <template x-if="message">
+      <div :class="`alert mt-4 fixed left-1/2 top-6 -translate-x-1/2 z-50 alert-${messageType}`" x-text="message" x-init="setTimeout(() => { message = ''; }, 1000)"></div>
     </template>
   </form>
 
-  <div x-ref="result"></div>
+  <template x-if="messageType === 'success' && short_url_result">
+    <div class="mt-4 flex items-center gap-2 justify-between">
+      <div>
+        <span>短網址：</span>
+        <a :href="short_url_result" target="_blank" class="link link-primary" x-text="short_url_result"></a>
+      </div>
+
+      <button @click="copyToClipboard(short_url_result)" type="button" class="ms-2">
+        <i class="fa-solid fa-link cursor-pointer"></i>
+      </button>
+    </div>
+  </template>
 </div>
 
 {% endblock main %}

--- a/frontend/templates/links/new.html
+++ b/frontend/templates/links/new.html
@@ -7,7 +7,7 @@
     <input x-model="password" placeholder="密碼 (選填)" type="password" class="input input-bordered w-full mb-2" />
     <textarea x-model="notes" placeholder="備註 (選填)" class="textarea textarea-bordered w-full mb-2"></textarea>
     <label class="flex items-center mb-2">
-      <input x-model="is_active" type="checkbox" class="checkbox mr-2" checked />
+      <input x-model="is_active" type="checkbox" class="checkbox mr-2" />
       啟用
     </label>
     <button type="submit" class="btn btn-primary" :disabled="isLoading">

--- a/frontend/templates/links/new.html
+++ b/frontend/templates/links/new.html
@@ -1,0 +1,25 @@
+{% extends 'layouts/default.html' %} {% block main %}
+
+<div x-data="shortenerForm()" @submit.prevent="submit" class="max-w-md mx-auto p-4">
+  <form>
+    <input x-model="original_url" placeholder="完整網址" class="input input-bordered w-full mb-2" />
+    <input x-model="short_url" placeholder="自訂代號 (可空)" class="input input-bordered w-full mb-2" />
+    <input x-model="password" placeholder="密碼 (選填)" type="password" class="input input-bordered w-full mb-2" />
+    <textarea x-model="notes" placeholder="備註 (選填)" class="textarea textarea-bordered w-full mb-2"></textarea>
+    <label class="flex items-center mb-2">
+      <input x-model="is_active" type="checkbox" class="checkbox mr-2" checked />
+      啟用
+    </label>
+    <button type="submit" class="btn btn-primary" :disabled="isLoading">
+      <span x-show="!isLoading">建立</span>
+      <span x-show="isLoading" class="loading loading-spinner loading-xs"></span>
+    </button>
+    <template x-if="errorMessage">
+      <div class="alert alert-error mt-4" x-text="errorMessage"></div>
+    </template>
+  </form>
+
+  <div x-ref="result"></div>
+</div>
+
+{% endblock main %}

--- a/frontend/templates/links/new.html
+++ b/frontend/templates/links/new.html
@@ -5,7 +5,17 @@
     <input x-model="original_url" placeholder="完整網址" class="input input-bordered w-full mb-2" />
     <input x-model="short_url" placeholder="自訂代號 (可空)" class="input input-bordered w-full mb-2" />
     <input x-model="password" placeholder="密碼 (選填)" type="password" class="input input-bordered w-full mb-2" />
-    <textarea x-model="notes" placeholder="備註 (選填)" class="textarea textarea-bordered w-full mb-2"></textarea>
+    <div style="margin-bottom: 10px">
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px">
+        <label for="notes">備註說明</label>
+        <!-- 按鈕觸發 fetchPageInfo 方法 -->
+        <button type="button" @click.prevent="fetchPageInfo" :disabled="isFetchingInfo" style="padding: 2px 8px; font-size: 0.8em">
+          <span x-text="isFetchingInfo ? '抓取中...' : '取得頁面資訊'"></span>
+        </button>
+      </div>
+      <!-- textarea 使用 x-model 雙向綁定 notes 狀態 -->
+      <textarea id="notes" x-model="notes" rows="4" style="width: 100%"></textarea>
+    </div>
     <label class="flex items-center mb-2">
       <input x-model="is_active" type="checkbox" class="checkbox mr-2" />
       啟用

--- a/nginx/prod.conf
+++ b/nginx/prod.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name shr.today www.shr.today; // 換成你的網域名稱
+    server_name shr.today www.shr.today localhost 127.0.0.1;
 
     location / {
         proxy_pass http://backend:8000;


### PR DESCRIPTION
- 新增「取得頁面資訊」API 與前端按鈕，能自動抓取原始網址的標題與描述並填入備註欄位。  
- 短網址支援密碼保護，若設有密碼，點擊短網址會先顯示輸入密碼頁面，驗證正確才可跳轉。  
- 前端（new.html）全面改用 Alpine.js 處理表單、訊息顯示、複製短網址等互動，並優化 UI/UX。  
- 成功與錯誤訊息皆以固定位置顯示，並於 1 秒後自動消失。  
- 新增後端 API 與必要依賴（requests、beautifulsoup4），修正 Docker、nginx、base template 等細節。  
- 提升縮網址服務的易用性、安全性與現代化介面體驗。